### PR TITLE
[1.14.5-2] added support for various layouts

### DIFF
--- a/Alloy/commands/compile/parsers/Ti.UI.Absolute.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Absolute.js
@@ -1,0 +1,2 @@
+// This is an alias for Ti.UI.AbsoluteLayout
+module.exports = require('./Ti.UI.AbsoluteLayout');

--- a/Alloy/commands/compile/parsers/Ti.UI.AbsoluteLayout.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.AbsoluteLayout.js
@@ -1,0 +1,23 @@
+var _ = require('lodash'),
+	styler = require('../styler'),
+	CU = require('../compilerUtils'),
+	U = require('../../../utils');
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	let code = '';
+
+	node.nodeName = 'View';		
+	node.setAttribute('layout', 'composite');
+
+	var nodeState = require('./default').parse(node, state);
+	code += nodeState.code;
+
+	// Generate runtime code using default
+	return _.extend(nodeState, {
+		code: code
+	});
+}

--- a/Alloy/commands/compile/parsers/Ti.UI.Horizontal.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Horizontal.js
@@ -1,0 +1,2 @@
+// This is an alias for Ti.UI.HorizontalLayout
+module.exports = require('./Ti.UI.HorizontalLayout');

--- a/Alloy/commands/compile/parsers/Ti.UI.HorizontalLayout.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.HorizontalLayout.js
@@ -1,0 +1,23 @@
+var _ = require('lodash'),
+	styler = require('../styler'),
+	CU = require('../compilerUtils'),
+	U = require('../../../utils');
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	let code = '';
+
+	node.nodeName = 'View';		
+	node.setAttribute('layout', 'horizontal');
+
+	var nodeState = require('./default').parse(node, state);
+	code += nodeState.code;
+
+	// Generate runtime code using default
+	return _.extend(nodeState, {
+		code: code
+	});
+}

--- a/Alloy/commands/compile/parsers/Ti.UI.Stack.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Stack.js
@@ -1,0 +1,2 @@
+// This is an alias for Ti.UI.StackLayout
+module.exports = require('./Ti.UI.StackLayout');

--- a/Alloy/commands/compile/parsers/Ti.UI.StackLayout.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.StackLayout.js
@@ -1,0 +1,29 @@
+var _ = require('lodash'),
+	styler = require('../styler'),
+	CU = require('../compilerUtils'),
+	U = require('../../../utils');
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	let code = '';
+
+	node.nodeName = 'View';		
+	const orientation = node.getAttribute('orientation');
+
+	if ( orientation === 'horizontal' ) {
+		node.setAttribute('layout', 'horizontal');
+	} else {
+		node.setAttribute('layout', 'vertical');
+	}
+
+	var nodeState = require('./default').parse(node, state);
+	code += nodeState.code;
+
+	// Generate runtime code using default
+	return _.extend(nodeState, {
+		code: code
+	});
+}

--- a/Alloy/commands/compile/parsers/Ti.UI.Vertical.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Vertical.js
@@ -1,0 +1,2 @@
+// This is an alias for Ti.UI.VerticalLayout
+module.exports = require('./Ti.UI.VerticalLayout');

--- a/Alloy/commands/compile/parsers/Ti.UI.VerticalLayout.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.VerticalLayout.js
@@ -1,0 +1,23 @@
+var _ = require('lodash'),
+	styler = require('../styler'),
+	CU = require('../compilerUtils'),
+	U = require('../../../utils');
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	let code = '';
+
+	node.nodeName = 'View';		
+	node.setAttribute('layout', 'vertical');
+
+	var nodeState = require('./default').parse(node, state);
+	code += nodeState.code;
+
+	// Generate runtime code using default
+	return _.extend(nodeState, {
+		code: code
+	});
+}

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,16 @@
 
 Titanium Turbo is a variation of Titanium Alloy that adds some enhancements and customizations for rapid development.
 
+## [1.14.5-2] - 2020-01-23
+
+### Added
+
+- Added support for StackLayout element (with shortcut alias of `stack` and orientation property that defaults to `vertical`) in xml views
+- Added support for VerticalLayout element (with shortcut alias of `vertical`) in xml views
+- Added support for HorizontalLayout element (with shortcut alias of `horizontal`) in xml views
+- Added support for AbsoluteLayout element (with shortcut alias of `absolute`) in xml views
+
+
 ## [1.14.5-1] - 2020-01-06
 
 ### Added
@@ -19,11 +29,13 @@ Titanium Turbo is a variation of Titanium Alloy that adds some enhancements and 
 
 - Updated to latest version of Alloy
 
+
 ## [1.14.1-18] - 2019-11-25
 
 ### Updated
 
 - Bug fixes for databinding
+
 
 ## [1.14.1-17] - 2019-10-24
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@titanium/turbo",
-  "version": "1.14.5-1",
+  "version": "1.14.5-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@titanium/turbo",
-	"version": "1.14.5-1",
+	"version": "1.14.5-2",
 	"description": "Turbo is a variation of Titanium Alloy that adds some enhancements and customizations for rapid development.",
 	"author": "Appcelerator, Inc. <info@appcelerator.com>",
 	"maintainers": [

--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,11 @@ npm install --save-dev @titanium/plugin-turbo
 * [x] Added support for using `WPATH()` in xml view attributes: [[ALOY-1253]](https://jira.appcelerator.org/browse/ALOY-1253)  [[Alloy PR]](https://github.com/appcelerator/alloy/pull/948)  ![Exclusive Turbo Feature](https://img.shields.io/badge/turbo-exclusive-blue.png) 
 * [x] Added support for using `~/` as a shortcut for WPATH() in xml view attributes: [[ALOY-1714]](https://jira.appcelerator.org/browse/ALOY-1714) [[Alloy PR]](https://github.com/appcelerator/alloy/pull/951)   ![Exclusive Turbo Feature](https://img.shields.io/badge/turbo-exclusive-blue.png) 
 * [x] Added support for using widget as primary control in xml view: [[ALOY-1256]](https://jira.appcelerator.org/browse/ALOY-1256) [[Alloy PR]](https://github.com/appcelerator/alloy/pull/949)  ![Exclusive Turbo Feature](https://img.shields.io/badge/turbo-exclusive-blue.png) 
+* [x] Added support for StackLayout element (with shortcut alias of `stack` and orientation property that defaults to `vertical`) in xml views:  ![Exclusive Turbo Feature](https://img.shields.io/badge/turbo-exclusive-blue.png) 
+* [x] Added support for VerticalLayout element (with shortcut alias of `vertical`) in xml views:  ![Exclusive Turbo Feature](https://img.shields.io/badge/turbo-exclusive-blue.png) 
+* [x] Added support for HorizontalLayout element (with shortcut alias of `horizontal`) in xml views:  ![Exclusive Turbo Feature](https://img.shields.io/badge/turbo-exclusive-blue.png) 
+* [x] Added support for AbsoluteLayout element (with shortcut alias of `absolute`) in xml views:  ![Exclusive Turbo Feature](https://img.shields.io/badge/turbo-exclusive-blue.png) 
+
 
 
 ## 🔗 Related Links


### PR DESCRIPTION
- Added support for StackLayout element (with shortcut alias of `stack` and orientation property that defaults to `vertical`) in xml views
- Added support for VerticalLayout element (with shortcut alias of `vertical`) in xml views
- Added support for HorizontalLayout element (with shortcut alias of `horizontal`) in xml views
- Added support for AbsoluteLayout element (with shortcut alias of `absolute`) in xml views