### PR TITLE
fix: pin colors@1.4.0 to fix security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"async": "^3.2.3",
 		"chmodr": "^1.2.0",
 		"cli-table3": "^0.6.1",
-		"colors": "^1.4.2",
+		"colors": "1.4.0",
 		"commander": "^8.3.0",
 		"ejs": "3.1.6",
 		"fs-extra": "^10.0.0",


### PR DESCRIPTION
A Security Vuln was identified in the Colors package for >1.4.0, offending packages being `1.4.1`, `1.4.44-liberty`
- [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source2](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source3](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR pins the color package to `1.4.0` as advised on the [snyk page](https://snyk.io/blog/open-source-maintainer-pulls-the-plug-on-npm-packages-colors-and-faker-now-what/)